### PR TITLE
Use transparent string to fix config error

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const TEXT_GREEN = '51, 255, 0';
 exports.decorateConfig = (config) => {
   return Object.assign({}, config, {
     foregroundColor: BRIGHT_GREEN,
-    backgroundColor: transparent,
+    backgroundColor: 'transparent',
     borderColor: BRIGHT_GREEN,
     cursorColor: '#40FFFF',
   });


### PR DESCRIPTION
Transparent is undefined, needs to be wrapped as a string